### PR TITLE
feat: ignore files in .gitignore when `yc upload .`

### DIFF
--- a/cmd/ignore_files.go
+++ b/cmd/ignore_files.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gitignore "github.com/sabhiram/go-gitignore"
+)
+
+// ToZipWithExclusions creates a zip file from src, ignoring files that match
+// the baseIgnorePatterns or any applicable .gitignore rule.
+func ToZipWithExclusions(src, dst string) error {
+	zipFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	// Base ignore patterns.
+	baseIgnorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", "*.js"}
+
+	// Cache for compiled .gitignore files: key is directory path.
+	gitIgnoreCache := make(map[string]*gitignore.GitIgnore)
+
+	// Helper to check if the path should be skipped by base ignore rules.
+	shouldSkipBase := func(relPath string, info os.FileInfo) bool {
+		parts := strings.Split(relPath, string(os.PathSeparator))
+		// Check each segment for exact match.
+		for _, part := range parts {
+			for _, pattern := range baseIgnorePatterns {
+				// If pattern contains wildcard, match against the filename.
+				if strings.Contains(pattern, "*") {
+					matched, err := filepath.Match(pattern, part)
+					if err == nil && matched {
+						return true
+					}
+				} else if part == pattern {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Helper to check .gitignore rules in effect for a given file.
+	shouldSkipGitignore := func(absPath, relPath string) bool {
+		// Walk from src up to the file's directory.
+		dir := filepath.Dir(absPath)
+		// Build a slice of directories from src to dir.
+		var dirs []string
+		for {
+			absSrc, err := filepath.Abs(src)
+			if err != nil {
+				break
+			}
+			absDir, err := filepath.Abs(dir)
+			if err != nil {
+				break
+			}
+			if !strings.HasPrefix(absDir, absSrc) {
+				break
+			}
+			dirs = append([]string{dir}, dirs...) // prepend
+			if absDir == absSrc {
+				break
+			}
+			dir = filepath.Dir(dir)
+		}
+
+		// For each directory, if a .gitignore exists, check if it ignores the file.
+		for _, d := range dirs {
+			ignoreFile := filepath.Join(d, ".gitignore")
+			gi, ok := gitIgnoreCache[d]
+			if !ok {
+				// Try to load .gitignore from this directory.
+				if _, err := os.Stat(ignoreFile); err == nil {
+					compiled, err := gitignore.CompileIgnoreFile(ignoreFile)
+					if err == nil {
+						gi = compiled
+					}
+				}
+				// Cache nil if not present or failed.
+				gitIgnoreCache[d] = gi
+			}
+			if gi != nil {
+				// Determine the path to test relative to the directory containing .gitignore.
+				relTest, err := filepath.Rel(d, absPath)
+				if err != nil {
+					continue
+				}
+				if gi.MatchesPath(relTest) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Walk through src.
+	err = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		// Compute path relative to src.
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		// Skip the root directory.
+		if relPath == "." {
+			return nil
+		}
+
+		// Check base ignore patterns.
+		if shouldSkipBase(relPath, info) {
+			// If it's a directory then skip its children.
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Check .gitignore rules.
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		if shouldSkipGitignore(absPath, relPath) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// If it's a directory, continue walking.
+		if info.IsDir() {
+			return nil
+		}
+
+		// Open the file.
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		// Create zip header using the relative file path
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		// Ensure consistent use of forward slashes.
+		header.Name = filepath.ToSlash(relPath)
+		header.Method = zip.Deflate
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(writer, file)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/ignore_files.go
+++ b/cmd/ignore_files.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"archive/zip"
-	"bufio"
-	"io"
+	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
-	gitignore "github.com/sabhiram/go-gitignore"
+	"github.com/codeglyph/go-dotignore"
 )
 
 // ToZipWithExclusions creates a zip file from src, ignoring files that match
@@ -23,170 +21,66 @@ func ZipWithExclusions(src, dst, vivgridIgnoreFile string) error {
 	zipWriter := zip.NewWriter(zipFile)
 	defer zipWriter.Close()
 
-	// Read ignore patterns from vivgridIgnoreFile.
-	f, err := os.Open(vivgridIgnoreFile)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+	vivMatcher, _ := dotignore.NewPatternMatcherFromFile(".vivgridignore")
+	// if err != nil {
+	// 	if !os.IsNotExist(err) {
+	// 		return err
+	// 	}
+	// }
 
-	scanner := bufio.NewScanner(f)
-	var baseIgnorePatterns []string
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Skip empty lines and comments.
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		baseIgnorePatterns = append(baseIgnorePatterns, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
+	gitMatcher, _ := dotignore.NewPatternMatcherFromFile(".gitignore")
+	// if err != nil {
+	// 	log.Println("** .gitignore absence")
+	// }
 
-	// Cache for compiled .gitignore files: key is directory path.
-	gitIgnoreCache := make(map[string]*gitignore.GitIgnore)
-
-	// Helper to check if the path should be skipped by base ignore rules.
-	shouldSkipBase := func(relPath string, info os.FileInfo) bool {
-		parts := strings.Split(relPath, string(os.PathSeparator))
-		// Check each segment for exact match.
-		for _, part := range parts {
-			for _, pattern := range baseIgnorePatterns {
-				// If pattern contains wildcard, match against the filename.
-				if strings.Contains(pattern, "*") {
-					matched, err := filepath.Match(pattern, part)
-					if err == nil && matched {
-						return true
-					}
-				} else if part == pattern {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	// Helper to check .gitignore rules in effect for a given file.
-	shouldSkipGitignore := func(absPath, relPath string) bool {
-		// Walk from src up to the file's directory.
-		dir := filepath.Dir(absPath)
-		// Build a slice of directories from src to dir.
-		var dirs []string
-		for {
-			absSrc, err := filepath.Abs(src)
-			if err != nil {
-				break
-			}
-			absDir, err := filepath.Abs(dir)
-			if err != nil {
-				break
-			}
-			if !strings.HasPrefix(absDir, absSrc) {
-				break
-			}
-			dirs = append([]string{dir}, dirs...) // prepend
-			if absDir == absSrc {
-				break
-			}
-			dir = filepath.Dir(dir)
-		}
-
-		// For each directory, if a .gitignore exists, check if it ignores the file.
-		for _, d := range dirs {
-			ignoreFile := filepath.Join(d, ".gitignore")
-			gi, ok := gitIgnoreCache[d]
-			if !ok {
-				// Try to load .gitignore from this directory.
-				if _, err := os.Stat(ignoreFile); err == nil {
-					compiled, err := gitignore.CompileIgnoreFile(ignoreFile)
-					if err == nil {
-						gi = compiled
-					}
-				}
-				// Cache nil if not present or failed.
-				gitIgnoreCache[d] = gi
-			}
-			if gi != nil {
-				// Determine the path to test relative to the directory containing .gitignore.
-				relTest, err := filepath.Rel(d, absPath)
-				if err != nil {
-					continue
-				}
-				if gi.MatchesPath(relTest) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	// Walk through src.
-	err = filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	// traverse the src directory, check each file against the ignore patterns
+	// and add it to the zip file if it doesn't match
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
+			log.Println("\t --err:", err)
 			return err
 		}
-		// Compute path relative to src.
-		relPath, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		// Skip the root directory.
-		if relPath == "." {
+
+		// ignore directories
+		if d.IsDir() {
 			return nil
 		}
 
-		// Check base ignore patterns.
-		if shouldSkipBase(relPath, info) {
-			// If it's a directory then skip its children.
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
+		// check if the file should be ignored
+		isIgnored := false
+		if vivMatcher != nil {
+			isIgnored, _ = vivMatcher.Matches(path)
+		}
+
+		if gitMatcher != nil && !isIgnored {
+			isIgnored, _ = gitMatcher.Matches(path)
+		}
+
+		if isIgnored {
 			return nil
 		}
 
-		// Check .gitignore rules.
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return err
-		}
-		if shouldSkipGitignore(absPath, relPath) {
-			if info.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
+		log.Println("\t ** add to zip, [", path, "]")
+		return nil
 
-		// If it's a directory, continue walking.
-		if info.IsDir() {
-			return nil
-		}
+		// // add the file to the zip archive
+		// relPath, err := filepath.Rel(src, path)
+		// if err != nil {
+		// 	return err
+		// }
 
-		// Open the file.
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
+		// file, err := os.Open(path)
+		// if err != nil {
+		// 	return err
+		// }
+		// defer file.Close()
 
-		// Create zip header using the relative file path.
-		header, err := zip.FileInfoHeader(info)
-		if err != nil {
-			return err
-		}
-		// Ensure consistent use of forward slashes.
-		header.Name = filepath.ToSlash(relPath)
-		header.Method = zip.Deflate
+		// zipFile, err := zipWriter.Create(relPath)
+		// if err != nil {
+		// 	return err
+		// }
 
-		writer, err := zipWriter.CreateHeader(header)
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(writer, file)
-		return err
+		// _, err = io.Copy(zipFile, file)
+		// return err
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,9 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -17,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/u-root/u-root/pkg/uzip"
 	"github.com/yomorun/yomo"
 	"github.com/yomorun/yomo/serverless"
 
@@ -84,10 +86,33 @@ func addUploadCmd(rootCmd *cobra.Command) {
 					defer os.Remove(zipPath)
 					defer f.Close()
 
-					err = uzip.ToZip(src, zipPath, "")
+					// these should be excluded from the zip
+					ignorePatterns := []string{".git", ".gitignore", "node_modules", "yc.yml", "*.js"}
+					// read .gitignore if it exists
+					gitignorePath := path.Join(src, ".gitignore")
+					if gitIgnoreData, err := os.ReadFile(gitignorePath); err == nil {
+						lines := strings.Split(string(gitIgnoreData), "\n")
+						for _, line := range lines {
+							line = strings.TrimSpace(line)
+							// Skip comments and empty lines
+							if line != "" && !strings.HasPrefix(line, "#") {
+								ignorePatterns = append(ignorePatterns, line)
+							}
+						}
+					}
+
+					// Create custom ToZip function with exclusions
+					err = ToZipWithExclusions(src, zipPath, ignorePatterns)
 					if err != nil {
 						return err
 					}
+
+					// err = uzip.ToZip(src, zipPath, "")
+					// if err != nil {
+					// 	return err
+					// }
+
+					// log.Println("----zip done----")
 
 					data, err = os.ReadFile(zipPath)
 					if err != nil {
@@ -485,3 +510,122 @@ const (
 	colorReset = "\033[0m"
 	colorGreen = "\033[34m"
 )
+
+// ToZipWithExclusions creates a zip file with the specified exclusions
+func ToZipWithExclusions(src, dst string, ignorePatterns []string) error {
+	zipFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	// Function to check if path matches any ignore pattern
+	isIgnored := func(path string, isDir bool) bool {
+		// Get relative path from source
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return false
+		}
+
+		if relPath == "." {
+			return false
+		}
+
+		for _, pattern := range ignorePatterns {
+			// Handle directory patterns ending with /
+			if strings.HasSuffix(pattern, "/") && isDir {
+				dirPattern := strings.TrimSuffix(pattern, "/")
+				if matched, _ := filepath.Match(dirPattern, filepath.Base(relPath)); matched {
+					return true
+				}
+				// Also check if directory is in the path
+				if strings.Contains(relPath, dirPattern+"/") {
+					return true
+				}
+			}
+
+			// Direct match for files
+			if matched, _ := filepath.Match(pattern, filepath.Base(relPath)); matched {
+				return true
+			}
+
+			// Handle glob patterns with *
+			if strings.Contains(pattern, "*") {
+				if matched, _ := filepath.Match(pattern, relPath); matched {
+					return true
+				}
+			}
+
+			// Check exact path match
+			if relPath == pattern || relPath+"/" == pattern {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Walk through the source directory
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip if path should be ignored
+		if isIgnored(path, info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Get relative path
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		// Skip root directory
+		if relPath == "." {
+			return nil
+		}
+
+		// Create zip header
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+
+		// Set proper path in the zip
+		header.Name = relPath
+		if info.IsDir() {
+			header.Name += "/"
+		} else {
+			// Use DEFLATE for regular files
+			header.Method = zip.Deflate
+		}
+
+		// For directories, just add the header
+		if info.IsDir() {
+			_, err = zipWriter.CreateHeader(header)
+			return err
+		}
+
+		// For files, add content
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		_, err = io.Copy(writer, file)
+		return err
+	})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,22 +82,6 @@ func addUploadCmd(rootCmd *cobra.Command) {
 					defer os.Remove(zipPath)
 					defer f.Close()
 
-					// these should be excluded from the zip
-					// ignorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", "*.js"}
-
-					// // read .gitignore if it exists
-					// gitignorePath := path.Join(src, ".gitignore")
-					// if gitIgnoreData, err := os.ReadFile(gitignorePath); err == nil {
-					// 	lines := strings.Split(string(gitIgnoreData), "\n")
-					// 	for _, line := range lines {
-					// 		line = strings.TrimSpace(line)
-					// 		// Skip comments and empty lines
-					// 		if line != "" && !strings.HasPrefix(line, "#") {
-					// 			ignorePatterns = append(ignorePatterns, line)
-					// 		}
-					// 	}
-					// }
-
 					// create a file with name .vivgridignore if it not exists
 					vivgridIgnoreFile := path.Join(src, ".vivgridignore")
 					if _, err := os.Stat(vivgridIgnoreFile); os.IsNotExist(err) {
@@ -108,7 +92,7 @@ func addUploadCmd(rootCmd *cobra.Command) {
 						}
 						defer f.Close()
 
-						ignorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", ".vivgridignore", "*.js"}
+						ignorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", ".vivgridignore", ".wrapper.ts", "*.js"}
 						// write the patterns to the file
 						for _, pattern := range ignorePatterns {
 							_, err = f.WriteString(pattern + "\n")
@@ -123,13 +107,6 @@ func addUploadCmd(rootCmd *cobra.Command) {
 					if err != nil {
 						return err
 					}
-
-					// err = uzip.ToZip(src, zipPath, "")
-					// if err != nil {
-					// 	return err
-					// }
-
-					// log.Println("----zip done----")
 
 					data, err = os.ReadFile(zipPath)
 					if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -98,8 +98,28 @@ func addUploadCmd(rootCmd *cobra.Command) {
 					// 	}
 					// }
 
+					// create a file with name .vivgridignore if it not exists
+					vivgridIgnoreFile := path.Join(src, ".vivgridignore")
+					if _, err := os.Stat(vivgridIgnoreFile); os.IsNotExist(err) {
+						// create the file
+						f, err := os.Create(vivgridIgnoreFile)
+						if err != nil {
+							return err
+						}
+						defer f.Close()
+
+						ignorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", ".vivgridignore", "*.js"}
+						// write the patterns to the file
+						for _, pattern := range ignorePatterns {
+							_, err = f.WriteString(pattern + "\n")
+							if err != nil {
+								return err
+							}
+						}
+					}
+
 					// Create custom ToZip function with exclusions
-					err = ToZipWithExclusions(src, zipPath)
+					err = ZipWithExclusions(src, zipPath, vivgridIgnoreFile)
 					if err != nil {
 						return err
 					}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/caarlos0/env/v6 v6.10.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/codeglyph/go-dotignore v1.0.2 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/matoous/go-nanoid/v2 v2.1.0
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
-	github.com/u-root/u-root v0.14.0
 	github.com/yomorun/yomo v1.18.9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDjyw0ULyrTYWeN0UNCCkmCWfjPnIA2W6oviI=
+github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
@@ -176,6 +178,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -185,8 +188,6 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/u-root/u-root v0.14.0 h1:Ka4T10EEML7dQ5XDvO9c3MBN8z4nuSnGjcd1jmU2ivg=
-github.com/u-root/u-root v0.14.0/go.mod h1:hAyZorapJe4qzbLWlAkmSVCJGbfoU9Pu4jpJ1WMluqE=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codeglyph/go-dotignore v1.0.2 h1:dG3wCMNvZHRZd4OUTqcBQC9wtH0cr6i8p+cGVUiIVMg=
+github.com/codeglyph/go-dotignore v1.0.2/go.mod h1:obs4k3skrieTSo4doCOzL+lrGP+X8y9/RCEI7WaCIHg=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
When `yc upload .` executes:
1. Follow `.vivgridignore` file ignore patterns, create it if absence.
2. Follow `.gitignore` file ignore patterns if it presents.

Known issue:

- currently didn't check subdirectory 
