### PR TITLE
refactor: ignore files from .gitignore

### DIFF
--- a/cmd/ignore_files.go
+++ b/cmd/ignore_files.go
@@ -11,8 +11,8 @@ import (
 )
 
 // ToZipWithExclusions creates a zip file from src, ignoring files that match
-// the ignore patterns from vivgridIgnoreFile or any applicable .gitignore rule.
-func ZipWithExclusions(src, dst, vivgridIgnoreFile string) error {
+// the ignore patterns from .gitignore rule.
+func ZipWithExclusions(src, dst string) error {
 	zipFile, err := os.Create(dst)
 	if err != nil {
 		return err
@@ -22,7 +22,6 @@ func ZipWithExclusions(src, dst, vivgridIgnoreFile string) error {
 	zipWriter := zip.NewWriter(zipFile)
 	defer zipWriter.Close()
 
-	vivMatcher, _ := dotignore.NewPatternMatcherFromFile(".vivgridignore")
 	gitMatcher, _ := dotignore.NewPatternMatcherFromFile(".gitignore")
 
 	// traverse the src directory, check each file against the ignore patterns
@@ -40,11 +39,8 @@ func ZipWithExclusions(src, dst, vivgridIgnoreFile string) error {
 
 		// check if the file should be ignored
 		isIgnored := false
-		if vivMatcher != nil {
-			isIgnored, _ = vivMatcher.Matches(path)
-		}
 
-		if gitMatcher != nil && !isIgnored {
+		if gitMatcher != nil {
 			isIgnored, _ = gitMatcher.Matches(path)
 		}
 
@@ -68,6 +64,7 @@ func ZipWithExclusions(src, dst, vivgridIgnoreFile string) error {
 		if err != nil {
 			return err
 		}
+
 		// Ensure consistent use of forward slashes.
 		header.Name = filepath.ToSlash(relPath)
 		header.Method = zip.Deflate

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,28 +79,8 @@ func addUploadCmd(rootCmd *cobra.Command) {
 					defer os.Remove(zipPath)
 					defer f.Close()
 
-					// create a file with name .vivgridignore if it not exists
-					vivgridIgnoreFile := path.Join(src, ".vivgridignore")
-					if _, err := os.Stat(vivgridIgnoreFile); os.IsNotExist(err) {
-						// create the file
-						f, err := os.Create(vivgridIgnoreFile)
-						if err != nil {
-							return err
-						}
-						defer f.Close()
-
-						ignorePatterns := []string{".git", ".gitignore", "node_modules/", "yc.yml", ".vivgridignore", ".wrapper.ts", "*.js"}
-						// write the patterns to the file
-						for _, pattern := range ignorePatterns {
-							_, err = f.WriteString(pattern + "\n")
-							if err != nil {
-								return err
-							}
-						}
-					}
-
 					// Create custom ToZip function with exclusions
-					err = ZipWithExclusions(src, zipPath, vivgridIgnoreFile)
+					err = ZipWithExclusions(src, zipPath)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
removing support for `.vivgridignore` files. The changes streamline the codebase and rely solely on `.gitignore` for exclusion patterns.
