### PR TITLE
feat: rename flags to --secret and --tool-name, remove --mesh-num flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -416,7 +416,7 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:   "yc",
-		Short: "Manage your global deployed Serverless LLM Functions on vivgrid.com from the command line",
+		Short: "Manage your globally deployed Serverless LLM Functions on vivgrid.com from the command line",
 	}
 
 	rootCmd.PersistentFlags().StringVar(&zipperAddr, "zipper", "zipper.vivgrid.com:9000", "Zipper address")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -394,8 +394,6 @@ func initViper() error {
 
 	if v.IsSet("mesh-num") {
 		meshNum = v.GetUint32("mesh-num")
-	} else {
-		meshNum = 7
 	}
 
 	return nil

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -414,7 +414,7 @@ func main() {
 
 	rootCmd := &cobra.Command{
 		Use:   "yc",
-		Short: "Manage your Geo-distributed Serverless on Vivgrid.com from the command line",
+		Short: "Manage your global deployed Serverless LLM Functions on vivgrid.com from the command line",
 	}
 
 	rootCmd.PersistentFlags().StringVar(&zipperAddr, "zipper", "zipper.vivgrid.com:9000", "Zipper address")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -394,6 +394,8 @@ func initViper() error {
 
 	if v.IsSet("mesh-num") {
 		meshNum = v.GetUint32("mesh-num")
+	} else {
+		meshNum = 7
 	}
 
 	return nil
@@ -420,7 +422,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&zipperAddr, "zipper", "zipper.vivgrid.com:9000", "Zipper address")
 	rootCmd.PersistentFlags().StringVar(&appSecret, "secret", "", "App secret")
 	rootCmd.PersistentFlags().StringVar(&sfnName, "tool-name", "my_first_llm_function_tool", "Serverless LLM Function name")
-	rootCmd.PersistentFlags().Uint32Var(&meshNum, "mesh-num", 7, "Number of mesh nodes")
+	// rootCmd.PersistentFlags().Uint32Var(&meshNum, "mesh-num", 7, "Number of mesh nodes")
 
 	err = initViper()
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -384,12 +384,12 @@ func initViper() error {
 		zipperAddr = v.GetString("zipper")
 	}
 
-	if v.IsSet("app-secret") {
-		appSecret = v.GetString("app-secret")
+	if v.IsSet("secret") {
+		appSecret = v.GetString("secret")
 	}
 
-	if v.IsSet("sfn-name") {
-		sfnName = v.GetString("sfn-name")
+	if v.IsSet("tool-name") {
+		sfnName = v.GetString("tool-name")
 	}
 
 	if v.IsSet("mesh-num") {
@@ -418,8 +418,8 @@ func main() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&zipperAddr, "zipper", "zipper.vivgrid.com:9000", "Zipper address")
-	rootCmd.PersistentFlags().StringVar(&appSecret, "app-secret", "", "App secret")
-	rootCmd.PersistentFlags().StringVar(&sfnName, "sfn-name", "my_first_llm_function_tool", "Serverless function name")
+	rootCmd.PersistentFlags().StringVar(&appSecret, "secret", "", "App secret")
+	rootCmd.PersistentFlags().StringVar(&sfnName, "tool-name", "my_first_llm_function_tool", "Serverless LLM Function name")
 	rootCmd.PersistentFlags().Uint32Var(&meshNum, "mesh-num", 7, "Number of mesh nodes")
 
 	err = initViper()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -392,9 +392,7 @@ func initViper() error {
 		sfnName = v.GetString("tool-name")
 	}
 
-	if v.IsSet("mesh-num") {
-		meshNum = v.GetUint32("mesh-num")
-	}
+	meshNum = 7
 
 	return nil
 }


### PR DESCRIPTION
- Renamed the `--app-secret` flag and corresponding configuration key to `--secret` for brevity and clarity
- remove `--mesh-num` flag and set default value to 7
- Updated the CLI description